### PR TITLE
laptop script for Sigma Computing

### DIFF
--- a/sigma
+++ b/sigma
@@ -1,0 +1,141 @@
+#!/bin/sh
+
+# Welcome to the laptop script!
+# Be prepared to turn your laptop (or desktop, no haters here)
+# into an awesome development machine.
+
+#n Ask for sudo upfront so we don't have to get it later
+sudo -v # Keep using sudo so the permissions don't time out
+# update existing sudo time stamp if set, otherwise do nothing.
+while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
+
+fancy_echo() {
+  printf "\n%s\n" "$1";
+}
+
+append_to_zshrc() {
+  text="$1"
+  skip_new_line="${2:-0}"
+
+  zshrc="$HOME/.zshrc"
+
+  if ! grep -Fqs "$text" "$zshrc"; then
+    [ "$skip_new_line" -ne 1 ] && printf "\n" >> "$zshrc";
+    printf "%s\n" "$text" >> "$zshrc"
+  fi
+}
+
+# shellcheck disable=SC2154
+trap 'ret=$?; test $ret -ne 0 && printf "$ret\n\nfailed\n\n" >&2; exit $ret' EXIT
+
+set -e
+
+[ ! -f "$HOME/.zshrc" ] && touch "$HOME/.zshrc";
+
+if [ "$(uname -m)" = "x86_64" ]; then
+  HOMEBREW_PREFIX="/usr/local"
+else
+  HOMEBREW_PREFIX="/opt/homebrew"
+  if [ "$(sysctl -n sysctl.proc_translated | awk -F': ' '{print $2}')" = "0" ]; then
+    echo "Rosetta Folder does not exist or Rosetta service is not running. Installing Rosetta..."
+    sudo softwareupdate --install-rosetta --agree-to-license
+  fi
+fi
+
+if [ -d "$HOMEBREW_PREFIX" ]; then
+  if ! [ -r "$HOMEBREW_PREFIX" ]; then
+    sudo chown -R "$LOGNAME:admin" "$HOMEBREW_PREFIX"
+  fi
+else
+  sudo mkdir "$HOMEBREW_PREFIX"
+  sudo chflags norestricted "$HOMEBREW_PREFIX"
+  sudo chown -R "$LOGNAME:admin" "$HOMEBREW_PREFIX"
+fi
+
+if ! command -v brew > /dev/null 2>&1; then
+  fancy_echo "Installing Homebrew ..."
+   NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh')"
+
+  append_to_zshrc "eval \"\$($HOMEBREW_PREFIX/bin/brew shellenv)\""
+  eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
+fi
+
+if brew list | grep -Fq brew-cask; then
+  fancy_echo "Uninstalling old Homebrew-Cask ..."
+  brew uninstall --force brew-cask
+fi
+
+fancy_echo "Updating Homebrew formulae ..."
+brew update --force
+
+brew bundle --file=- <<EOF
+tap "homebrew/services"
+tap "homebrew/cask-versions"
+tap "nodenv/nodenv"
+
+# Mac Casks
+cask "alfred"
+cask "docker"
+cask "vagrant"
+cask "iterm2"
+cask "licecap"
+cask "postman"
+cask "rectangle"
+cask "macdown"
+cask "textmate"
+cask "utm"
+
+cask "karabiner-elements"
+
+# Libraries & Tools
+brew "ctags"
+brew "gnupg2"
+brew "openssl"
+brew "reattach-to-user-namespace"
+brew "gcc"
+brew "gnu-sed"
+brew "git"
+brew "hub"
+brew "htop"
+brew "watch"
+brew "the_silver_searcher"
+brew "tmux"
+brew "vim"
+brew "zsh"
+brew "tmate"
+brew "grep"
+brew "rename"
+brew "jq"
+brew "forego"
+brew "pkg-config"
+brew "shellcheck"
+
+# languages
+
+brew "nodenv"
+brew "node-build"
+brew "nodenv-nvmrc"
+brew "rbenv"
+brew "ruby-build"
+
+EOF
+
+# shellcheck disable=SC2016
+fancy_echo "Adding rbenv init to zsh profile"
+append_to_zshrc "eval \"$(rbenv init - --no-rehash)\"" 1
+eval "$(rbenv init -)"
+
+fancy_echo "Adding nodenv init to zsh profile"
+append_to_zshrc "eval \"$(nodenv init -)\"" 1
+eval "$(nodenv init -)"
+
+if [ "$(command -v zsh)" != "$HOMEBREW_PREFIX/bin/zsh" ]; then
+  shell_path="$(command -v zsh)"
+
+  fancy_echo "Changing your shell to zsh ..."
+  if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
+    fancy_echo "Adding '$shell_path' to /etc/shells"
+    sudo sh -c "echo $shell_path >> /etc/shells"
+  fi
+  sudo chsh -s "$shell_path" "$USER"
+fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a macOS laptop provisioning script that installs Homebrew packages/casks, configures nodenv/rbenv, and sets up zsh with Apple Silicon/Rosetta handling.
> 
> - **New script `sigma`**:
>   - Keeps `sudo` alive; sets error trap; ensures `~/.zshrc` and helper functions.
>   - Detects Intel vs Apple Silicon; sets `HOMEBREW_PREFIX`; installs Rosetta if needed; fixes Homebrew dir permissions.
>   - Installs Homebrew if missing; updates; removes legacy `brew-cask`.
>   - **Homebrew Bundle**:
>     - Taps: `homebrew/services`, `homebrew/cask-versions`, `nodenv/nodenv`.
>     - Casks: `iterm2`, `docker`, `vagrant`, `alfred`, `rectangle`, `postman`, etc.
>     - Formulae: `git`, `tmux`, `vim`, `shellcheck`, `htop`, `gnu-sed`, `jq`, `ctags`, etc.
>     - Languages: `nodenv`, `node-build`, `nodenv-nvmrc`, `rbenv`, `ruby-build`.
>   - Appends and evaluates `rbenv`/`nodenv` init in `~/.zshrc`.
>   - Switches default shell to `zsh`, adding it to `/etc/shells` if necessary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67f60efd157dbd9b4ef71e60350ff0daa212efa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->