### PR TITLE
Add mac-agentic and mac-openclaw scripts; clean up mac script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: ShellCheck
-        run: shellcheck mac ubuntu pi
+        run: shellcheck mac-x86_64 mac-agentic mac-openclaw ubuntu pi
+
+  psscriptanalyzer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          Invoke-ScriptAnalyzer -Path windows -Severity Error

--- a/mac
+++ b/mac
@@ -28,11 +28,6 @@ if ! command -v brew > /dev/null 2>&1; then
   eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
 fi
 
-if brew list | grep -Fq brew-cask; then
-  echo "Uninstalling old Homebrew-Cask ..."
-  brew uninstall --force brew-cask
-fi
-
 echo "Updating Homebrew formulae ..."
 brew update --force
 
@@ -41,7 +36,7 @@ cask "alfred"
 cask "docker-desktop"
 cask "google-chrome"
 cask "iterm2"
-cask "licecap"
+cask "kap"
 cask "postman"
 cask "rectangle"
 cask "slack"
@@ -243,10 +238,7 @@ fi
 ###############################################################################
 
 for app in "Calendar" "Contacts" "Dock" "Finder" \
-  "Mail" "Safari" "SystemUIServer"; do
-  killall "$app" > /dev/null 2>&1 || true
-done
-for app in "iTunes" "Music"; do
+  "Mail" "Music" "Safari" "SystemUIServer"; do
   killall "$app" > /dev/null 2>&1 || true
 done
 

--- a/mac-agentic
+++ b/mac-agentic
@@ -19,11 +19,6 @@ if ! command -v brew > /dev/null 2>&1; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
-if brew list | grep -Fq brew-cask; then
-  echo "Uninstalling old Homebrew-Cask ..."
-  brew uninstall --force brew-cask
-fi
-
 echo "Updating Homebrew formulae ..."
 brew update --force
 
@@ -32,7 +27,7 @@ cask "alfred"
 cask "docker-desktop"
 cask "google-chrome"
 cask "iterm2"
-cask "licecap"
+cask "kap"
 cask "postman"
 cask "rectangle"
 cask "slack"
@@ -91,7 +86,7 @@ fi
 # Install VS Code Claude extension (requires VS Code to be installed and 'code' in PATH)
 if command -v code > /dev/null 2>&1; then
   echo "Installing VS Code Claude extension ..."
-  code --install-extension anthropics.claude-code 2>/dev/null || true
+  code --install-extension anthropic.claude-code 2>/dev/null || true
 fi
 
 shell_path="$(command -v zsh)"
@@ -248,10 +243,7 @@ fi
 ###############################################################################
 
 for app in "Calendar" "Contacts" "Dock" "Finder" \
-  "Mail" "Safari" "SystemUIServer"; do
-  killall "$app" > /dev/null 2>&1 || true
-done
-for app in "iTunes" "Music"; do
+  "Mail" "Music" "Safari" "SystemUIServer"; do
   killall "$app" > /dev/null 2>&1 || true
 done
 

--- a/mac-agentic
+++ b/mac-agentic
@@ -242,8 +242,7 @@ fi
 # Restart affected applications                                               #
 ###############################################################################
 
-for app in "Calendar" "Contacts" "Dock" "Finder" \
-  "Mail" "Music" "Safari" "SystemUIServer"; do
+for app in "Dock" "Finder" "Safari" "SystemUIServer"; do
   killall "$app" > /dev/null 2>&1 || true
 done
 

--- a/mac-agentic
+++ b/mac-agentic
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-# Welcome to the machine script!
+# Welcome to the agentic-dev machine script!
+# Sets up a human dev machine with agentic AI workflows and local model support.
 
 # Ask for sudo upfront so we don't have to get it later
 sudo -v
@@ -12,20 +13,10 @@ while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
-if [ "$(uname -m)" = "x86_64" ]; then
-  HOMEBREW_PREFIX="/usr/local"
-else
-  HOMEBREW_PREFIX="/opt/homebrew"
-  if ! /usr/bin/arch -x86_64 /usr/bin/true 2>/dev/null; then
-    echo "Installing Rosetta ..."
-    sudo softwareupdate --install-rosetta --agree-to-license
-  fi
-fi
-
 if ! command -v brew > /dev/null 2>&1; then
   echo "Installing Homebrew ..."
   NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh')"
-  eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
 if brew list | grep -Fq brew-cask; then
@@ -52,6 +43,11 @@ cask "textmate"
 cask "karabiner-elements"
 cask "ngrok"
 cask "qlstephen"
+
+# AI tooling
+cask "claude"
+cask "ollama"
+cask "visual-studio-code"
 
 # Libraries & Tools
 brew "gnupg"
@@ -86,7 +82,16 @@ if [ -f "$(brew --prefix asdf 2>/dev/null)/libexec/asdf.sh" ]; then
     echo "Node.js $node_version set as global default"
   fi
 
+  echo "Installing Claude Code ..."
+  npm install -g @anthropic-ai/claude-code
+
   # Config files (.zshrc, .asdfrc) are managed by dotfiles - do not modify
+fi
+
+# Install VS Code Claude extension (requires VS Code to be installed and 'code' in PATH)
+if command -v code > /dev/null 2>&1; then
+  echo "Installing VS Code Claude extension ..."
+  code --install-extension anthropics.claude-code 2>/dev/null || true
 fi
 
 shell_path="$(command -v zsh)"

--- a/mac-openclaw
+++ b/mac-openclaw
@@ -112,13 +112,10 @@ defaults write com.google.iterm2 PromptOnQuit -bool true
 defaults write com.google.iterm2 QuitWhenAllWindowsClosed -bool true
 
 # Disable Time Machine — not needed on an autonomous agent box
-defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
-hash tmutil > /dev/null 2>&1 && sudo tmutil disable || true
-
-# Set OPENCLAW_KEEP_TIME_MACHINE=1 to skip the above
-if [ "${OPENCLAW_KEEP_TIME_MACHINE:-0}" = "1" ]; then
-  defaults delete com.apple.TimeMachine DoNotOfferNewDisksForBackup 2>/dev/null || true
-  hash tmutil > /dev/null 2>&1 && sudo tmutil enable || true
+# Set OPENCLAW_KEEP_TIME_MACHINE=1 to skip
+if [ "${OPENCLAW_KEEP_TIME_MACHINE:-0}" != "1" ]; then
+  defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+  hash tmutil > /dev/null 2>&1 && sudo tmutil disable || true
 fi
 
 for app in "Dock" "Finder" "SystemUIServer"; do

--- a/mac-openclaw
+++ b/mac-openclaw
@@ -14,25 +14,10 @@ while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
-if [ "$(uname -m)" = "x86_64" ]; then
-  HOMEBREW_PREFIX="/usr/local"
-else
-  HOMEBREW_PREFIX="/opt/homebrew"
-  if ! /usr/bin/arch -x86_64 /usr/bin/true 2>/dev/null; then
-    echo "Installing Rosetta ..."
-    sudo softwareupdate --install-rosetta --agree-to-license
-  fi
-fi
-
 if ! command -v brew > /dev/null 2>&1; then
   echo "Installing Homebrew ..."
   NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh')"
-  eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
-fi
-
-if brew list | grep -Fq brew-cask; then
-  echo "Uninstalling old Homebrew-Cask ..."
-  brew uninstall --force brew-cask
+  eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
 echo "Updating Homebrew formulae ..."

--- a/mac-openclaw
+++ b/mac-openclaw
@@ -115,7 +115,9 @@ defaults write com.google.iterm2 QuitWhenAllWindowsClosed -bool true
 # Set OPENCLAW_KEEP_TIME_MACHINE=1 to skip
 if [ "${OPENCLAW_KEEP_TIME_MACHINE:-0}" != "1" ]; then
   defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
-  hash tmutil > /dev/null 2>&1 && sudo tmutil disable || true
+  if hash tmutil > /dev/null 2>&1; then
+    sudo tmutil disable
+  fi
 fi
 
 for app in "Dock" "Finder" "SystemUIServer"; do

--- a/mac-openclaw
+++ b/mac-openclaw
@@ -1,0 +1,172 @@
+#!/bin/sh
+
+# Welcome to the mac-openclaw machine script!
+# Sets up a Mac to run OpenClaw as a persistent autonomous agent.
+# After this script completes, run: openclaw onboard
+
+# Ask for sudo upfront so we don't have to get it later
+sudo -v
+
+# Keep using sudo so the permissions don't time out by updating existing sudo time stamp if set, otherwise do nothing.
+while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
+
+# shellcheck disable=SC2154
+trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+set -e
+
+if [ "$(uname -m)" = "x86_64" ]; then
+  HOMEBREW_PREFIX="/usr/local"
+else
+  HOMEBREW_PREFIX="/opt/homebrew"
+  if ! /usr/bin/arch -x86_64 /usr/bin/true 2>/dev/null; then
+    echo "Installing Rosetta ..."
+    sudo softwareupdate --install-rosetta --agree-to-license
+  fi
+fi
+
+if ! command -v brew > /dev/null 2>&1; then
+  echo "Installing Homebrew ..."
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh')"
+  eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
+fi
+
+if brew list | grep -Fq brew-cask; then
+  echo "Uninstalling old Homebrew-Cask ..."
+  brew uninstall --force brew-cask
+fi
+
+echo "Updating Homebrew formulae ..."
+brew update --force
+
+brew bundle --file=- <<EOF
+# GUI apps — kept for physical access / debugging
+cask "alfred"
+cask "docker-desktop"
+cask "google-chrome"
+cask "iterm2"
+cask "rectangle"
+cask "slack"
+cask "textmate"
+
+# Tunneling — useful for exposing the gateway or webhooks
+cask "ngrok"
+
+# Libraries & Tools
+brew "gnupg"
+brew "openssl"
+brew "shellcheck"
+brew "gcc"
+brew "git"
+brew "htop"
+brew "watch"
+brew "the_silver_searcher"
+brew "tmux"
+brew "vim"
+brew "zsh"
+brew "tmate"
+brew "grep"
+brew "jq"
+brew "forego"
+
+# Node.js v22 — required by OpenClaw
+brew "node@22"
+EOF
+
+# Put node@22 on PATH for this session
+brew link node@22 --overwrite --force 2>/dev/null || true
+node22_bin="$(brew --prefix node@22 2>/dev/null)/bin"
+if [ -d "$node22_bin" ]; then
+  export PATH="$node22_bin:$PATH"
+fi
+
+shell_path="$(command -v zsh)"
+echo "Ensure shell is zsh at '$shell_path' ..."
+if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
+  echo "Add '$shell_path' to /etc/shells"
+  sudo sh -c "echo $shell_path >> /etc/shells"
+fi
+sudo chsh -s "$shell_path" "$USER"
+
+###############################################################################
+# macOS defaults                                                              #
+###############################################################################
+
+echo "Configuring macOS defaults ..."
+
+# Keep background processes alive — prevents macOS from auto-terminating services
+defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true
+
+# No iCloud document syncing
+defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
+
+# Reveal IP address, hostname, OS version when clicking clock in login window
+sudo defaults write /Library/Preferences/com.apple.loginwindow AdminHostInfo HostName
+
+# Locale
+defaults write NSGlobalDomain AppleLanguages -array "en"
+defaults write NSGlobalDomain AppleLocale -string "en_US@currency=USD"
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+
+# Require password immediately after screensaver
+defaults write com.apple.screensaver askForPassword -int 1
+defaults write com.apple.screensaver askForPasswordDelay -int 0
+
+# No .DS_Store files on network volumes
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+
+# No confirmation dialogs that could block automation
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+defaults write com.apple.finder WarnOnEmptyTrash -bool false
+
+# Terminal/iTerm2 — for physical access sessions
+defaults write com.apple.terminal StringEncodings -array 4
+defaults write com.google.iterm2 DimBackgroundWindows -bool false
+defaults write com.google.iterm2 DimInactiveSplitPanes -bool false
+defaults write com.google.iterm2 HideScrollbar -bool true
+defaults write com.google.iterm2 PromptOnQuit -bool true
+defaults write com.google.iterm2 QuitWhenAllWindowsClosed -bool true
+
+# Disable Time Machine — not needed on an autonomous agent box
+defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+hash tmutil > /dev/null 2>&1 && sudo tmutil disable || true
+
+# Set OPENCLAW_KEEP_TIME_MACHINE=1 to skip the above
+if [ "${OPENCLAW_KEEP_TIME_MACHINE:-0}" = "1" ]; then
+  defaults delete com.apple.TimeMachine DoNotOfferNewDisksForBackup 2>/dev/null || true
+  hash tmutil > /dev/null 2>&1 && sudo tmutil enable || true
+fi
+
+for app in "Dock" "Finder" "SystemUIServer"; do
+  killall "$app" > /dev/null 2>&1 || true
+done
+
+echo "macOS defaults configured."
+
+###############################################################################
+# OpenClaw                                                                    #
+###############################################################################
+
+echo "Installing OpenClaw ..."
+curl -fsSL --proto '=https' --tlsv1.2 'https://openclaw.ai/install.sh' -o /tmp/openclaw-install.sh
+OPENCLAW_NO_ONBOARD=1 OPENCLAW_NO_PROMPT=1 bash /tmp/openclaw-install.sh --no-onboard --no-prompt
+rm -f /tmp/openclaw-install.sh
+
+# Install and start the Gateway as a launchd service
+if command -v openclaw > /dev/null 2>&1; then
+  echo "Installing OpenClaw Gateway service ..."
+  openclaw gateway install
+  openclaw gateway start
+  echo "Gateway service installed and started."
+else
+  echo "Warning: openclaw not found on PATH after install."
+  echo "Open a new shell, then run:"
+  echo "  openclaw gateway install && openclaw gateway start"
+fi
+
+echo ""
+echo "============================================================"
+echo "OpenClaw is installed. To finish setup, run:"
+echo "  openclaw onboard"
+echo ""
+echo "This will configure your messaging channels and API keys."
+echo "============================================================"

--- a/mac-x86_64
+++ b/mac-x86_64
@@ -12,20 +12,10 @@ while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
-if [ "$(uname -m)" = "x86_64" ]; then
-  HOMEBREW_PREFIX="/usr/local"
-else
-  HOMEBREW_PREFIX="/opt/homebrew"
-  if ! /usr/bin/arch -x86_64 /usr/bin/true 2>/dev/null; then
-    echo "Installing Rosetta ..."
-    sudo softwareupdate --install-rosetta --agree-to-license
-  fi
-fi
-
 if ! command -v brew > /dev/null 2>&1; then
   echo "Installing Homebrew ..."
   NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh')"
-  eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
+  eval "$(/usr/local/bin/brew shellenv)"
 fi
 
 echo "Updating Homebrew formulae ..."

--- a/mac-x86_64
+++ b/mac-x86_64
@@ -227,8 +227,7 @@ fi
 # Restart affected applications                                               #
 ###############################################################################
 
-for app in "Calendar" "Contacts" "Dock" "Finder" \
-  "Mail" "Music" "Safari" "SystemUIServer"; do
+for app in "Dock" "Finder" "Safari" "SystemUIServer"; do
   killall "$app" > /dev/null 2>&1 || true
 done
 

--- a/pi
+++ b/pi
@@ -33,7 +33,7 @@ sudo apt update
 
 sudo apt install -y \
   build-essential gcc libssl-dev \
-  zsh exuberant-ctags git htop gh jq gnupg2 openssl openssh-server \
+  zsh universal-ctags git htop gh jq gnupg openssl openssh-server \
   silversearcher-ag shellcheck tmate tmux vim watch \
   iptables-persistent \
   docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/ubuntu
+++ b/ubuntu
@@ -32,7 +32,7 @@ fi
 
 sudo apt update
 
-apt_packages="build-essential gcc libssl-dev zsh exuberant-ctags git htop gh jq gnupg2 openssl openssh-server silversearcher-ag shellcheck tmate tmux vim watch"
+apt_packages="build-essential gcc libssl-dev zsh universal-ctags git htop gh jq gnupg openssl openssh-server silversearcher-ag shellcheck tmate tmux vim watch"
 if [ -z "${LAPTOP_SKIP_DOCKER}" ]; then
   apt_packages="$apt_packages docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin"
 fi


### PR DESCRIPTION
- Add mac-agentic: human dev machine with agentic AI workflows (Apple Silicon only), adds Ollama, Claude Desktop, VS Code, Claude Code
- Add mac-openclaw: autonomous OpenClaw agent machine, stripped of human-oriented apps and macOS defaults, installs OpenClaw and starts the Gateway as a launchd service
- mac/mac-openclaw: remove redundant pre-install Homebrew directory setup (mkdir/chflags/chown) — Homebrew handles this itself
- mac-agentic: remove x86_64 support and Rosetta install (Apple Silicon only); use hardcoded /opt/homebrew path