### PR TITLE
Install Chrome on ubuntu-openclaw; log every script run

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Standalone [OpenClaw](https://openclaw.ai) machine on Ubuntu 26.04 LTS Desktop (
 
 **OpenClaw:** installed via official installer; wire to Claude CLI with `openclaw models auth login --provider anthropic --method cli --set-default`, then run `openclaw onboard --install-daemon`
 
+**Browser:** Google Chrome stable (via Google's official apt repository) — a real browser for OpenClaw's QR-code login and browser automation
+
 **WhatsApp channel:** set up after onboarding by scanning QR code in browser (use RDP if no physical display)
 
 **iMessage channel:** connect to a mac-openclaw iMessage bridge via the `@openclaw/imessage` plugin over Tailscale
@@ -184,6 +186,37 @@ Same as Ubuntu plus **headless setup**: enables and starts the SSH service and c
 **Step 1** sets up [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) with Ubuntu, [Chocolatey](https://chocolatey.org/), and Windows apps: git, vscode, docker-desktop, googlechrome, slack, powershell. **Requires Administrator**; reboot if prompted.
 
 **Step 2** runs the Ubuntu script inside WSL (see Install section above). Use `LAPTOP_SKIP_DOCKER=1` — Docker Desktop provides Docker to WSL. After both steps you get the same environment as Mac/Ubuntu (asdf, Node.js LTS, zsh, tmux, etc.).
+
+Run log
+-------
+
+Every install script appends one line to `~/.laptop/runs.log` each time it runs,
+so you can see which script ran on which box, when, and whether it worked —
+without having to remember. Each line is tab-separated:
+
+```
+<timestamp>	<script>	<hostname>	<commit>	<outcome>	<duration>	exit=<code>
+```
+
+For example:
+
+```
+2026-06-04T11:42:07-0700	ubuntu-openclaw	openclaw-box	38149cd1f0a2	ok	214s	exit=0
+2026-06-02T09:15:33-0700	mac-agentic	Jonathons-MBP	5a6c09ebc7d1	fail	   8s	exit=1
+```
+
+- **commit** is the `main` HEAD short SHA fetched from GitHub at run time (the
+  version the piped script came from); `unknown` when offline.
+- **outcome** is `ok` / `fail` (`reboot` on Windows when WSL needs a restart).
+- **duration** is wall-clock seconds for the run.
+
+The Windows script writes the same format to `%USERPROFILE%\.laptop\runs.log`.
+
+View the most recent runs with:
+
+```sh
+column -t -s "$(printf '\t')" ~/.laptop/runs.log | tail
+```
 
 Contributing
 ------------

--- a/mac-agentic
+++ b/mac-agentic
@@ -9,8 +9,30 @@ sudo -v
 # Keep using sudo so the permissions don't time out by updating existing sudo time stamp if set, otherwise do nothing.
 while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 
+# Run logging -- append one tab-separated line per run to ~/.laptop/runs.log so
+# it's easy to see which script ran on which host, when, for how long, against
+# which repo commit, and whether it succeeded. The commit is fetched lazily at
+# exit (via curl or wget) and falls back to "unknown" when offline or unset.
+LAPTOP_SCRIPT="mac-agentic"
+LAPTOP_RUN_START=$(date +%s)
+
+log_run() {
+  _ret="$1"
+  _dur=$(( $(date +%s) - LAPTOP_RUN_START ))
+  if [ "$_ret" -eq 0 ]; then _outcome="ok"; else _outcome="fail"; fi
+  _api="https://api.github.com/repos/jonstorer/laptop/commits/main"
+  _commit=$( { curl -fsSL "$_api" 2>/dev/null || wget -qO- "$_api" 2>/dev/null; } \
+    | grep -m1 '"sha"' | cut -d'"' -f4 | cut -c1-12)
+  [ -n "$_commit" ] || _commit="unknown"
+  mkdir -p "$HOME/.laptop"
+  printf '%s\t%s\t%s\t%s\t%s\t%ss\texit=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" \
+    "$LAPTOP_SCRIPT" "$(hostname)" "$_commit" \
+    "$_outcome" "$_dur" "$_ret" >> "$HOME/.laptop/runs.log"
+}
+
 # shellcheck disable=SC2154
-trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
 if ! command -v brew > /dev/null 2>&1; then

--- a/mac-openclaw
+++ b/mac-openclaw
@@ -12,8 +12,30 @@ sudo -v
 # Keep using sudo so the permissions don't time out
 while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 
+# Run logging -- append one tab-separated line per run to ~/.laptop/runs.log so
+# it's easy to see which script ran on which host, when, for how long, against
+# which repo commit, and whether it succeeded. The commit is fetched lazily at
+# exit (via curl or wget) and falls back to "unknown" when offline or unset.
+LAPTOP_SCRIPT="mac-openclaw"
+LAPTOP_RUN_START=$(date +%s)
+
+log_run() {
+  _ret="$1"
+  _dur=$(( $(date +%s) - LAPTOP_RUN_START ))
+  if [ "$_ret" -eq 0 ]; then _outcome="ok"; else _outcome="fail"; fi
+  _api="https://api.github.com/repos/jonstorer/laptop/commits/main"
+  _commit=$( { curl -fsSL "$_api" 2>/dev/null || wget -qO- "$_api" 2>/dev/null; } \
+    | grep -m1 '"sha"' | cut -d'"' -f4 | cut -c1-12)
+  [ -n "$_commit" ] || _commit="unknown"
+  mkdir -p "$HOME/.laptop"
+  printf '%s\t%s\t%s\t%s\t%s\t%ss\texit=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" \
+    "$LAPTOP_SCRIPT" "$(hostname)" "$_commit" \
+    "$_outcome" "$_dur" "$_ret" >> "$HOME/.laptop/runs.log"
+}
+
 # shellcheck disable=SC2154
-trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
 ###############################################################################

--- a/mac-x86_64
+++ b/mac-x86_64
@@ -8,8 +8,30 @@ sudo -v
 # Keep using sudo so the permissions don't time out by updating existing sudo time stamp if set, otherwise do nothing.
 while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 
+# Run logging -- append one tab-separated line per run to ~/.laptop/runs.log so
+# it's easy to see which script ran on which host, when, for how long, against
+# which repo commit, and whether it succeeded. The commit is fetched lazily at
+# exit (via curl or wget) and falls back to "unknown" when offline or unset.
+LAPTOP_SCRIPT="mac-x86_64"
+LAPTOP_RUN_START=$(date +%s)
+
+log_run() {
+  _ret="$1"
+  _dur=$(( $(date +%s) - LAPTOP_RUN_START ))
+  if [ "$_ret" -eq 0 ]; then _outcome="ok"; else _outcome="fail"; fi
+  _api="https://api.github.com/repos/jonstorer/laptop/commits/main"
+  _commit=$( { curl -fsSL "$_api" 2>/dev/null || wget -qO- "$_api" 2>/dev/null; } \
+    | grep -m1 '"sha"' | cut -d'"' -f4 | cut -c1-12)
+  [ -n "$_commit" ] || _commit="unknown"
+  mkdir -p "$HOME/.laptop"
+  printf '%s\t%s\t%s\t%s\t%s\t%ss\texit=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" \
+    "$LAPTOP_SCRIPT" "$(hostname)" "$_commit" \
+    "$_outcome" "$_dur" "$_ret" >> "$HOME/.laptop/runs.log"
+}
+
 # shellcheck disable=SC2154
-trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
 if ! command -v brew > /dev/null 2>&1; then

--- a/pi
+++ b/pi
@@ -8,8 +8,30 @@ sudo -v
 # Keep using sudo so the permissions don't time out by updating existing sudo time stamp if set, otherwise do nothing.
 while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 
+# Run logging -- append one tab-separated line per run to ~/.laptop/runs.log so
+# it's easy to see which script ran on which host, when, for how long, against
+# which repo commit, and whether it succeeded. The commit is fetched lazily at
+# exit (via curl or wget) and falls back to "unknown" when offline or unset.
+LAPTOP_SCRIPT="pi"
+LAPTOP_RUN_START=$(date +%s)
+
+log_run() {
+  _ret="$1"
+  _dur=$(( $(date +%s) - LAPTOP_RUN_START ))
+  if [ "$_ret" -eq 0 ]; then _outcome="ok"; else _outcome="fail"; fi
+  _api="https://api.github.com/repos/jonstorer/laptop/commits/main"
+  _commit=$( { curl -fsSL "$_api" 2>/dev/null || wget -qO- "$_api" 2>/dev/null; } \
+    | grep -m1 '"sha"' | cut -d'"' -f4 | cut -c1-12)
+  [ -n "$_commit" ] || _commit="unknown"
+  mkdir -p "$HOME/.laptop"
+  printf '%s\t%s\t%s\t%s\t%s\t%ss\texit=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" \
+    "$LAPTOP_SCRIPT" "$(hostname)" "$_commit" \
+    "$_outcome" "$_dur" "$_ret" >> "$HOME/.laptop/runs.log"
+}
+
 # shellcheck disable=SC2154
-trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
 sudo apt update

--- a/ubuntu
+++ b/ubuntu
@@ -8,8 +8,30 @@ sudo -v
 # Keep using sudo so the permissions don't time out by updating existing sudo time stamp if set, otherwise do nothing.
 while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 
+# Run logging -- append one tab-separated line per run to ~/.laptop/runs.log so
+# it's easy to see which script ran on which host, when, for how long, against
+# which repo commit, and whether it succeeded. The commit is fetched lazily at
+# exit (via curl or wget) and falls back to "unknown" when offline or unset.
+LAPTOP_SCRIPT="ubuntu"
+LAPTOP_RUN_START=$(date +%s)
+
+log_run() {
+  _ret="$1"
+  _dur=$(( $(date +%s) - LAPTOP_RUN_START ))
+  if [ "$_ret" -eq 0 ]; then _outcome="ok"; else _outcome="fail"; fi
+  _api="https://api.github.com/repos/jonstorer/laptop/commits/main"
+  _commit=$( { curl -fsSL "$_api" 2>/dev/null || wget -qO- "$_api" 2>/dev/null; } \
+    | grep -m1 '"sha"' | cut -d'"' -f4 | cut -c1-12)
+  [ -n "$_commit" ] || _commit="unknown"
+  mkdir -p "$HOME/.laptop"
+  printf '%s\t%s\t%s\t%s\t%s\t%ss\texit=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" \
+    "$LAPTOP_SCRIPT" "$(hostname)" "$_commit" \
+    "$_outcome" "$_dur" "$_ret" >> "$HOME/.laptop/runs.log"
+}
+
 # shellcheck disable=SC2154
-trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
 sudo apt update

--- a/ubuntu-openclaw
+++ b/ubuntu-openclaw
@@ -15,8 +15,30 @@ while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
 # a pipe. DEBIAN_FRONTEND=noninteractive suppresses all interactive apt prompts.
 export DEBIAN_FRONTEND=noninteractive
 
+# Run logging -- append one tab-separated line per run to ~/.laptop/runs.log so
+# it's easy to see which script ran on which host, when, for how long, against
+# which repo commit, and whether it succeeded. The commit is fetched lazily at
+# exit (via curl or wget) and falls back to "unknown" when offline or unset.
+LAPTOP_SCRIPT="ubuntu-openclaw"
+LAPTOP_RUN_START=$(date +%s)
+
+log_run() {
+  _ret="$1"
+  _dur=$(( $(date +%s) - LAPTOP_RUN_START ))
+  if [ "$_ret" -eq 0 ]; then _outcome="ok"; else _outcome="fail"; fi
+  _api="https://api.github.com/repos/jonstorer/laptop/commits/main"
+  _commit=$( { curl -fsSL "$_api" 2>/dev/null || wget -qO- "$_api" 2>/dev/null; } \
+    | grep -m1 '"sha"' | cut -d'"' -f4 | cut -c1-12)
+  [ -n "$_commit" ] || _commit="unknown"
+  mkdir -p "$HOME/.laptop"
+  printf '%s\t%s\t%s\t%s\t%s\t%ss\texit=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" \
+    "$LAPTOP_SCRIPT" "$(hostname)" "$_commit" \
+    "$_outcome" "$_dur" "$_ret" >> "$HOME/.laptop/runs.log"
+}
+
 # shellcheck disable=SC2154
-trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
 # Wait for apt locks to be released
@@ -229,6 +251,27 @@ fi
 
 sudo systemctl enable tailscaled
 sudo systemctl start tailscaled
+
+###############################################################################
+# Google Chrome -- real browser for OpenClaw (WhatsApp QR, web automation)   #
+###############################################################################
+
+# OpenClaw needs a real browser for QR-code login and browser automation.
+# Google publishes amd64-only debs via its official apt repository.
+if ! command -v google-chrome > /dev/null 2>&1; then
+  echo "Installing Google Chrome ..."
+  sudo install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+    | sudo gpg --dearmor --batch --yes -o /etc/apt/keyrings/google-chrome.gpg
+  sudo chmod 644 /etc/apt/keyrings/google-chrome.gpg
+  echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+    | sudo tee /etc/apt/sources.list.d/google-chrome.list > /dev/null
+  wait_for_apt
+  sudo -E apt update
+  sudo -E apt install -y google-chrome-stable
+else
+  echo "Google Chrome already installed, skipping."
+fi
 
 ###############################################################################
 # OpenClaw                                                                    #

--- a/windows
+++ b/windows
@@ -2,10 +2,34 @@
 
 Write-Host "Running laptop script..."
 
+# --- Run logging -------------------------------------------------------------
+# Append one tab-separated line per run to ~\.laptop\runs.log so it's easy to
+# see which script ran on which host, when, for how long, against which repo
+# commit, and the outcome (ok / fail / reboot). The commit is fetched from the
+# GitHub API and falls back to "unknown" when offline.
+$LaptopScript = "windows"
+$LaptopRunStart = Get-Date
+function Write-LaptopRun {
+  param([string]$Outcome)
+  $commit = "unknown"
+  try {
+    $resp = Invoke-RestMethod -Uri "https://api.github.com/repos/jonstorer/laptop/commits/main" `
+      -Headers @{ "User-Agent" = "laptop-script" } -ErrorAction Stop
+    if ($resp.sha) { $commit = $resp.sha.Substring(0, [Math]::Min(12, $resp.sha.Length)) }
+  } catch { }
+  $dur = [int]((Get-Date) - $LaptopRunStart).TotalSeconds
+  $dir = Join-Path $HOME ".laptop"
+  New-Item -ItemType Directory -Force -Path $dir | Out-Null
+  $line = "{0}`t{1}`t{2}`t{3}`t{4}`t{5}s" -f `
+    (Get-Date -Format "yyyy-MM-ddTHH:mm:sszzz"), $LaptopScript, $env:COMPUTERNAME, $commit, $Outcome, $dur
+  Add-Content -Path (Join-Path $dir "runs.log") -Value $line
+}
+
 # Require Administrator for WSL installation
 $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 if (-Not $isAdmin) {
   Write-Host "This script must be run as Administrator (required for WSL setup). Right-click PowerShell and 'Run as Administrator'." -ForegroundColor Red
+  Write-LaptopRun "fail"
   exit 1
 }
 
@@ -45,6 +69,7 @@ if (-Not $wslReady) {
   if (-Not $wslReady) {
     Write-Host ""
     Write-Host "WSL installation requires a reboot. Please restart your computer, then run this script again." -ForegroundColor Yellow
+    Write-LaptopRun "reboot"
     exit 0
   }
 }
@@ -84,3 +109,5 @@ Write-Host "  2. If first time: complete Ubuntu username/password setup" -Foregr
 Write-Host "  3. Run the Ubuntu script from the README (use LAPTOP_SKIP_DOCKER=1 for WSL)" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "Docker: Enable 'Use the WSL 2 based engine' in Docker Desktop Settings > General." -ForegroundColor Cyan
+
+Write-LaptopRun "ok"


### PR DESCRIPTION
OpenClaw needs a real browser for QR-code login and browser automation, so add Google Chrome stable to ubuntu-openclaw via Google's official amd64 apt repository (same keyring/apt-repo pattern as gh, Node, and the Claude CLI).

Add run logging to every install script: each run appends one tab-separated line to ~/.laptop/runs.log with timestamp, script, hostname, main-HEAD short SHA, outcome, duration, and exit code. This makes it easy to see which script ran on which box and when.

The six shell scripts extend their existing EXIT trap (already capturing the exit code) so success and failure are both logged without changing the original behavior. The commit is fetched at exit via curl-or-wget, falling back to "unknown" offline. The Windows script writes the same format to %USERPROFILE%\.laptop and logs ok / fail / reboot at its three exit points.