### PR TITLE
Add mac-headless profile for a lid-closed Claude Code devbox

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
       - name: ShellCheck
-        run: shellcheck ubuntu-openclaw ubuntu pi mac-agentic mac-openclaw mac-x86_64
+        run: shellcheck ubuntu-openclaw ubuntu pi mac-agentic mac-openclaw mac-headless mac-x86_64

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
 **CLI tools:** curl, forego, git, gnupg, openssl, shellcheck, jq, yq, htop, the_silver_searcher, tmate, tmux, vim, wget, zsh, gh, mise, tailscale
 
-**Node.js:** [mise](https://mise.jdx.dev) sets a global LTS default; per-repo pinned versions (e.g. mono-node's `mise.toml`/`.nvmrc`) take over automatically when you `cd` in.
+**Node.js:** [mise](https://mise.jdx.dev) sets a global LTS default; per-repo pinned versions (`mise.toml`/`.nvmrc`) take over automatically when you `cd` in.
 
 **SSH:** Remote Login enabled for remote access.
 

--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ Writes a `TODO.md` to the working directory with live status checks for each man
 
 Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
-**Casks:** claude, claude-code, google-chrome
+**Casks:** claude-code, google-chrome
 
-**CLI tools:** git, gnupg, openssl, shellcheck, jq, htop, ripgrep, tmux, vim, zsh, gh, nodenv, tailscale
+**CLI tools:** git, gnupg, openssl, shellcheck, jq, htop, the_silver_searcher, tmux, vim, zsh, gh, mise, tailscale
 
-**Node.js:** nodenv installs the latest LTS (even-numbered major version) and sets it as the global default.
+**Node.js:** [mise](https://mise.jdx.dev) sets a global LTS default; per-repo pinned versions (e.g. mono-node's `mise.toml`/`.nvmrc`) take over automatically when you `cd` in.
 
 **SSH:** Remote Login enabled for remote access.
 
@@ -164,9 +164,7 @@ Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
 **Tailscale:** installed and daemon started; run `sudo tailscale up` to authenticate.
 
-**Power management:** `pmset` tuned for unattended operation (wake on network access, auto-restart after power failure). Actual sleep prevention with the lid closed is left to an app like Amphetamine, not scripted.
-
-**Scheduled jobs:** `~/.laptop/jobs` is created with a `README.md` documenting the LaunchAgent pattern for adding recurring jobs later — no job is installed by default.
+**Power management:** `pmset` tuned for unattended operation — `disablesleep` keeps the system awake independent of the display (which stays off with the lid closed), plus wake-on-network-access and auto-restart-after-power-failure. No third-party keep-awake app needed.
 
 Sets zsh as the default shell and applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync, no Time Machine new-disk prompts).
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Support For:
 
 * macOS (Apple Silicon) — `mac-agentic`
 * macOS (Apple Silicon or Intel x86_64) — `mac-openclaw`
+* macOS (Apple Silicon) — `mac-headless`
 * macOS (Intel x86_64) — `mac-x86_64`
 * Ubuntu 20.04+ — `ubuntu`
 * Ubuntu 26.04 LTS Desktop (amd64) — `ubuntu-openclaw`
@@ -42,6 +43,14 @@ Sets up a Mac as an iMessage bridge for a ubuntu-openclaw installation. BlueBubb
 
 ```sh
 curl -H "Cache-Control: no-cache" -fsS 'https://raw.githubusercontent.com/jonstorer/laptop/main/mac-openclaw' | sh
+```
+
+#### Mac — Headless Devbox (Apple Silicon)
+
+Sets up a MacBook Pro to run lid-closed, screen-off, as a Claude Code automation box: MCP-connected agent work (e.g. Jira cleanup) now, general dev work later. Reachable via SSH, Screen Sharing, and Tailscale.
+
+```sh
+curl -H "Cache-Control: no-cache" -fsS 'https://raw.githubusercontent.com/jonstorer/laptop/main/mac-headless' | sh
 ```
 
 #### Mac — Intel (x86_64)
@@ -138,6 +147,30 @@ Uses [Homebrew](http://brew.sh/) for package management. Works on both Apple Sil
 Sets zsh as the default shell and applies macOS defaults optimized for autonomous/headless operation.
 
 Writes a `TODO.md` to the working directory with live status checks for each manual step.
+
+#### Mac — Headless Devbox (Apple Silicon)
+
+Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
+
+**Casks:** claude, claude-code, google-chrome
+
+**CLI tools:** git, gnupg, openssl, shellcheck, jq, htop, ripgrep, tmux, vim, zsh, gh, nodenv, tailscale
+
+**Node.js:** nodenv installs the latest LTS (even-numbered major version) and sets it as the global default.
+
+**SSH:** Remote Login enabled for remote access.
+
+**Screen Sharing:** enabled for remote desktop — the fallback for interactive steps (browser OAuth for Claude/MCP login) since the box has no physical display.
+
+**Tailscale:** installed and daemon started; run `sudo tailscale up` to authenticate.
+
+**Power management:** `pmset` tuned for unattended operation (wake on network access, auto-restart after power failure). Actual sleep prevention with the lid closed is left to an app like Amphetamine, not scripted.
+
+**Scheduled jobs:** `~/.laptop/jobs` is created with a `README.md` documenting the LaunchAgent pattern for adding recurring jobs later — no job is installed by default.
+
+Sets zsh as the default shell and applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync, no Time Machine new-disk prompts).
+
+Writes a `TODO.md` to `$HOME` with live status checks for each manual step (Claude auth, Atlassian MCP, Tailscale auth, git identity, gh auth, automatic login, Amphetamine).
 
 #### Mac — Intel (x86_64)
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
 **Node.js:** [mise](https://mise.jdx.dev) sets a global LTS default; per-repo pinned versions (`mise.toml`/`.nvmrc`) take over automatically when you `cd` in.
 
-**SSH:** Remote Login enabled for remote access.
+**SSH:** attempts to enable Remote Login via `systemsetup`; macOS requires Full Disk Access for the terminal running the script to actually allow this, so it's also a live-checked manual step in `TODO.md` if it doesn't take.
 
 **Screen Sharing:** enabled for remote desktop — the fallback for interactive steps (browser OAuth for Claude/MCP login, or just working on the box directly with Alfred/iTerm2/Rectangle/TextMate) since the box has no physical display.
 

--- a/README.md
+++ b/README.md
@@ -152,15 +152,15 @@ Writes a `TODO.md` to the working directory with live status checks for each man
 
 Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
-**Casks:** claude-code, google-chrome
+**Casks:** claude-code, google-chrome, alfred, iterm2, rectangle, textmate
 
-**CLI tools:** git, gnupg, openssl, shellcheck, jq, htop, the_silver_searcher, tmux, vim, zsh, gh, mise, tailscale
+**CLI tools:** curl, forego, git, gnupg, openssl, shellcheck, jq, yq, htop, the_silver_searcher, tmate, tmux, vim, wget, zsh, gh, mise, tailscale
 
 **Node.js:** [mise](https://mise.jdx.dev) sets a global LTS default; per-repo pinned versions (e.g. mono-node's `mise.toml`/`.nvmrc`) take over automatically when you `cd` in.
 
 **SSH:** Remote Login enabled for remote access.
 
-**Screen Sharing:** enabled for remote desktop — the fallback for interactive steps (browser OAuth for Claude/MCP login) since the box has no physical display.
+**Screen Sharing:** enabled for remote desktop — the fallback for interactive steps (browser OAuth for Claude/MCP login, or just working on the box directly with Alfred/iTerm2/Rectangle/TextMate) since the box has no physical display.
 
 **Tailscale:** installed and daemon started; run `sudo tailscale up` to authenticate.
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
 Sets zsh as the default shell and applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync, no Time Machine new-disk prompts).
 
-Writes a `TODO.md` to `$HOME` with live status checks for each manual step (Claude auth, Atlassian MCP, Tailscale auth, git identity, gh auth), plus notes on keeping automatic login off and the LaunchDaemon pattern for background work that should start without any login session.
+Writes a `TODO.md` to `$HOME` with live status checks for each manual step (Claude auth, Atlassian MCP, Tailscale auth, git identity, gh auth).
 
 #### Mac — Intel (x86_64)
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
 **Tailscale:** installed and daemon started; run `sudo tailscale up` to authenticate.
 
-**Power management:** `pmset` tuned for unattended operation — `disablesleep` keeps the system awake independent of the display (which stays off with the lid closed), plus wake-on-network-access and auto-restart-after-power-failure. No third-party keep-awake app needed.
+**Power management:** `pmset` tuned for unattended operation — `disablesleep` keeps the system awake independent of the display (which stays off with the lid closed), plus wake-on-network-access and auto-restart-after-power-failure.
 
 Sets zsh as the default shell and applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync, no Time Machine new-disk prompts).
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
 **Power management:** `pmset` tuned for unattended operation — `disablesleep` keeps the system awake independent of the display (which stays off with the lid closed), plus wake-on-network-access and auto-restart-after-power-failure.
 
-Sets zsh as the default shell and applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync, no Time Machine new-disk prompts).
+Sets zsh as the default shell and applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync).
 
 Writes a `TODO.md` to `$HOME` with live status checks for each manual step (Claude auth, Atlassian MCP, Tailscale auth, git identity, gh auth).
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Uses [Homebrew](http://brew.sh/) for package management. Apple Silicon only.
 
 Sets zsh as the default shell and applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync, no Time Machine new-disk prompts).
 
-Writes a `TODO.md` to `$HOME` with live status checks for each manual step (Claude auth, Atlassian MCP, Tailscale auth, git identity, gh auth, automatic login, Amphetamine).
+Writes a `TODO.md` to `$HOME` with live status checks for each manual step (Claude auth, Atlassian MCP, Tailscale auth, git identity, gh auth), plus notes on keeping automatic login off and the LaunchDaemon pattern for background work that should start without any login session.
 
 #### Mac — Intel (x86_64)
 

--- a/mac-headless
+++ b/mac-headless
@@ -4,9 +4,8 @@
 # Sets up a headless MacBook Pro (Apple Silicon, lid closed, screen off) as a
 # Claude Code automation box: MCP-connected agent work now (e.g. Jira
 # cleanup), general dev work later. Reachable via SSH / Screen Sharing /
-# Tailscale, tuned to survive reboots and stay out of the way of unattended
-# automation. Actual sleep prevention with the lid closed is left to
-# Amphetamine (or similar) -- see the summary at the end.
+# Tailscale, tuned to survive reboots and stay awake (screen off, system on)
+# without any physical console.
 # After this script completes, follow the manual steps shown in the summary.
 
 # Ask for sudo upfront so we don't have to get it later
@@ -57,7 +56,6 @@ brew update --force
 
 brew bundle --file=- <<EOF
 # AI tooling
-cask "claude"
 cask "claude-code"
 
 # Browser -- one-time OAuth flows (Claude login, MCP auth) done over Screen
@@ -71,12 +69,12 @@ brew "openssl"
 brew "shellcheck"
 brew "jq"
 brew "htop"
-brew "ripgrep"
+brew "the_silver_searcher"
 brew "tmux"
 brew "vim"
 brew "zsh"
 brew "gh"
-brew "nodenv"
+brew "mise"
 
 # Remote access
 brew "tailscale"
@@ -84,16 +82,19 @@ EOF
 
 brew upgrade
 
-# Configure nodenv and install latest Node.js LTS
-if command -v nodenv > /dev/null 2>&1; then
-  echo "Setting up nodenv and Node.js ..."
+# Node.js via mise -- mono-node (the primary repo this box will work in)
+# standardizes on mise over nvm/nodenv, pinning versions per-repo via
+# mise.toml/.nvmrc. `mise use --global` just sets the fallback used outside
+# any pinned repo.
+if command -v mise > /dev/null 2>&1; then
+  echo "Setting up mise and Node.js ..."
+  mise use --global node@lts
+  echo "Node.js LTS set as global default via mise"
 
-  # Node.js LTS releases use even-numbered major versions
-  latest_lts=$(nodenv install -l 2>/dev/null | sed 's/^[[:space:]]*//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '$1 % 2 == 0' | tail -1)
-  if [ -n "$latest_lts" ]; then
-    nodenv install -s "$latest_lts"
-    nodenv global "$latest_lts"
-    echo "Node.js $latest_lts set as global default"
+  ZPROFILE="$HOME/.zprofile.local"
+  if ! grep -qF 'mise activate' "$ZPROFILE" 2>/dev/null; then
+    # shellcheck disable=SC2016
+    printf '\neval "$(mise activate zsh)"\n' >> "$ZPROFILE"
   fi
 
   # Shell init (.zshrc) is managed by dotfiles - do not modify
@@ -137,11 +138,14 @@ sudo brew services start tailscale
 # Power management -- tuned for an unattended box                            #
 ###############################################################################
 
-# Wake on network access (lets SSH/Tailscale wake it if it does sleep) and
-# auto-restart after a power failure -- important for a box tucked away with
-# no one around to press the power button. Actual sleep *prevention* with the
-# lid closed is intentionally left to Amphetamine (see summary) rather than
-# scripted here with pmset disablesleep.
+# Prevent system sleep entirely (independent of the display, which stays off
+# with the lid closed) -- this is what actually keeps a lid-closed MacBook
+# reachable, no third-party keep-awake app needed. Also wake on network
+# access (lets SSH/Tailscale wake it if it ever does sleep) and auto-restart
+# after a power failure -- important for a box tucked away with no one
+# around to press the power button. Trade-off: no idle power savings, which
+# is the point for an always-on automation box.
+sudo pmset -a disablesleep 1
 sudo pmset -a womp 1
 sudo pmset -a autorestart 1
 
@@ -186,52 +190,6 @@ done
 echo "macOS defaults configured."
 
 ###############################################################################
-# Scheduled jobs -- scaffolding only, no job installed yet                   #
-###############################################################################
-
-JOBS_DIR="$HOME/.laptop/jobs"
-mkdir -p "$JOBS_DIR"
-
-JOBS_README="$JOBS_DIR/README.md"
-if [ ! -f "$JOBS_README" ]; then
-  cat > "$JOBS_README" <<'EOF'
-# Scheduled jobs
-
-Convention for adding a recurring job to this box: a script here, plus a
-LaunchAgent that runs it on an interval. Follow the idempotent load pattern
-used by mac-openclaw's `poke-messages` agent (unload-then-reload, since
-`bootstrap` errors if the label is already loaded):
-
-    JOB_PLIST="$HOME/Library/LaunchAgents/com.user.<job-name>.plist"
-
-    cat > "$JOB_PLIST" <<PLIST
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-        <key>Label</key>
-        <string>com.user.<job-name></string>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>StartInterval</key>
-        <integer>300</integer>
-        <key>ProgramArguments</key>
-        <array>
-            <string>$HOME/.laptop/jobs/<job-name>.sh</string>
-        </array>
-    </dict>
-    </plist>
-    PLIST
-
-    launchctl bootout "gui/$(id -u)/com.user.<job-name>" 2>/dev/null || true
-    launchctl bootstrap "gui/$(id -u)" "$JOB_PLIST"
-
-Use `StartCalendarInterval` instead of `StartInterval` for clock-time (rather
-than every-N-seconds) schedules.
-EOF
-fi
-
-###############################################################################
 # TODO.md -- manual steps with live status                                   #
 ###############################################################################
 
@@ -257,8 +215,6 @@ _Last updated: $_GENERATED — rerun mac-headless to refresh status._
 - [$_GIT] Set git identity: \`git config --global user.name "Name" && git config --global user.email "you@example.com"\`
 - [$_GH] Authenticate GitHub CLI: \`gh auth login\`
 - [$_AUTOLOGIN] Enable automatic login (survives unattended reboots): System Settings -> Users & Groups -> Login Options -> Automatic login. Not scripted here since it requires storing your account password.
-- [ ] Install & configure Amphetamine (or similar) from the App Store to keep the machine awake with the lid closed -- pmset alone won't prevent clamshell sleep on a MacBook with no external display
-- [ ] Add scheduled jobs under \`~/.laptop/jobs\` as needed (see \`~/.laptop/jobs/README.md\` for the LaunchAgent pattern)
 EOF
 
 ###############################################################################
@@ -278,6 +234,5 @@ echo ""
 echo "Tailscale: daemon started -- run 'sudo tailscale up' to authenticate."
 echo "After auth, SSH and Screen Sharing work from anywhere via Tailscale IP."
 echo ""
-echo "Reminder: install Amphetamine to keep this box awake with the lid closed."
 echo "Manual steps: $TODO_FILE"
 echo "============================================================"

--- a/mac-headless
+++ b/mac-headless
@@ -54,7 +54,7 @@ echo "macOS: $(sw_vers -productVersion 2>/dev/null || echo unknown), arch: $(una
 ###############################################################################
 
 echo "Syncing system clock ..."
-sudo sntp -sS time.apple.com 2>/dev/null || true
+sudo sntp -sS time.apple.com > /dev/null 2>&1 || true
 
 ###############################################################################
 # Homebrew                                                                    #
@@ -144,7 +144,8 @@ fi
 ###############################################################################
 
 echo "Enabling SSH Remote Login ..."
-sudo systemsetup -setremotelogin on
+sudo systemsetup -setremotelogin on 2>/dev/null || \
+  echo "Could not enable Remote Login -- see TODO.md (needs Full Disk Access)."
 
 ###############################################################################
 # Screen Sharing -- enable for remote desktop (needed for interactive OAuth  #
@@ -222,6 +223,7 @@ _ok() { sh -c "$1" > /dev/null 2>&1 && printf 'x' || printf ' '; }
 
 _CLAUDE=$(_ok "claude auth status")
 _MCP=$(_ok "claude mcp list | grep -qi atlassian")
+_SSH=$(_ok "sudo systemsetup -getremotelogin 2>/dev/null | grep -qi 'On'")
 _TS=$(_ok "tailscale status")
 _GIT=$(_ok "git config --global user.name | grep -q . && git config --global user.email | grep -q .")
 _GH=$(_ok "gh auth status")
@@ -235,6 +237,7 @@ _Last updated: $_GENERATED — rerun mac-headless to refresh status._
 
 - [$_CLAUDE] Authenticate Claude CLI: \`claude\` (interactive TTY required -- use SSH or Screen Sharing)
 - [$_MCP] Add the Atlassian MCP for Jira cleanup: \`claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse\` then authenticate (opens a browser -- use Screen Sharing/Chrome)
+- [$_SSH] Enable SSH Remote Login: grant Full Disk Access to this terminal app (System Settings -> Privacy & Security -> Full Disk Access), then run \`sudo systemsetup -setremotelogin on\` (or re-run this script) -- macOS won't allow this from a script without it
 - [$_TS] Authenticate Tailscale: \`sudo tailscale up\`
 - [$_GIT] Set git identity: \`git config --global user.name "Name" && git config --global user.email "you@example.com"\`
 - [$_GH] Authenticate GitHub CLI: \`gh auth login\`

--- a/mac-headless
+++ b/mac-headless
@@ -40,6 +40,14 @@ log_run() {
 trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 set -e
 
+# Run with LAPTOP_DEBUG=1 for full command tracing -- helpful when testing
+# on a new machine (e.g. a VM) and diagnosing exactly where a failure
+# happened, since set -e otherwise exits silently with no indication of
+# which command failed beyond its own error output.
+[ -n "${LAPTOP_DEBUG:-}" ] && set -x
+
+echo "macOS: $(sw_vers -productVersion 2>/dev/null || echo unknown), arch: $(uname -m)"
+
 ###############################################################################
 # Homebrew                                                                    #
 ###############################################################################
@@ -89,7 +97,7 @@ brew upgrade
 if command -v mise > /dev/null 2>&1; then
   echo "Setting up mise and Node.js ..."
   mise use --global node@lts
-  echo "Node.js LTS set as global default via mise"
+  echo "Node.js LTS set as global default via mise: $(mise exec node -- node -v 2>/dev/null || echo 'unable to verify')"
 
   ZPROFILE="$HOME/.zprofile.local"
   if ! grep -qF 'mise activate' "$ZPROFILE" 2>/dev/null; then
@@ -117,6 +125,7 @@ fi
 # SSH -- enable Remote Login for remote access                               #
 ###############################################################################
 
+echo "Enabling SSH Remote Login ..."
 pgrep sshd > /dev/null 2>&1 || \
   sudo launchctl load -w /System/Library/LaunchDaemons/ssh.plist
 
@@ -125,6 +134,7 @@ pgrep sshd > /dev/null 2>&1 || \
 # steps, since the box has no physical display)                              #
 ###############################################################################
 
+echo "Enabling Screen Sharing ..."
 nc -z localhost 5900 2>/dev/null || \
   sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.screensharing.plist
 
@@ -132,6 +142,7 @@ nc -z localhost 5900 2>/dev/null || \
 # Tailscale -- start daemon (run 'sudo tailscale up' to authenticate)       #
 ###############################################################################
 
+echo "Starting Tailscale daemon ..."
 sudo brew services start tailscale
 
 ###############################################################################
@@ -145,6 +156,7 @@ sudo brew services start tailscale
 # after a power failure -- important for a box tucked away with no one
 # around to press the power button. Trade-off: no idle power savings, which
 # is the point for an always-on automation box.
+echo "Tuning pmset for unattended operation ..."
 sudo pmset -a disablesleep 1
 sudo pmset -a womp 1
 sudo pmset -a autorestart 1

--- a/mac-headless
+++ b/mac-headless
@@ -200,7 +200,6 @@ _MCP=$(_ok "claude mcp list | grep -qi atlassian")
 _TS=$(_ok "tailscale status")
 _GIT=$(_ok "git config --global user.name | grep -q . && git config --global user.email | grep -q .")
 _GH=$(_ok "gh auth status")
-_AUTOLOGIN=$(_ok "sudo defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser")
 _GENERATED=$(date '+%Y-%m-%d %H:%M:%S')
 TODO_FILE="$HOME/TODO.md"
 
@@ -214,7 +213,8 @@ _Last updated: $_GENERATED — rerun mac-headless to refresh status._
 - [$_TS] Authenticate Tailscale: \`sudo tailscale up\`
 - [$_GIT] Set git identity: \`git config --global user.name "Name" && git config --global user.email "you@example.com"\`
 - [$_GH] Authenticate GitHub CLI: \`gh auth login\`
-- [$_AUTOLOGIN] Enable automatic login (survives unattended reboots): System Settings -> Users & Groups -> Login Options -> Automatic login. Not scripted here since it requires storing your account password.
+- [ ] Do NOT enable automatic login (System Settings -> Users & Groups -> Login Options) -- opening the lid should always require a password, never show an unlocked desktop
+- [ ] For background work (Claude, scheduled jobs) to run at boot without any GUI/SSH login ever happening, use a LaunchDaemon with \`UserName\` set to run as you (in /Library/LaunchDaemons, loaded at the system level) rather than a LaunchAgent, which needs a login session first. Before relying on this: verify whether Claude's stored credentials need your login Keychain unlocked (GUI login) to be read -- a LaunchDaemon started before any login may not be able to authenticate. Also check whether FileVault is enabled: if so, a full reboot stops at the pre-boot disk-unlock screen and nothing (not even the LaunchDaemon) starts until someone is physically there to unlock it.
 EOF
 
 ###############################################################################

--- a/mac-headless
+++ b/mac-headless
@@ -200,9 +200,6 @@ defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
 defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
 defaults write com.apple.finder WarnOnEmptyTrash -bool false
 
-# Don't prompt to use new disks for Time Machine backups
-sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true 2>/dev/null || true
-
 for app in "Dock" "Finder" "SystemUIServer"; do
   killall "$app" > /dev/null 2>&1 || true
 done

--- a/mac-headless
+++ b/mac-headless
@@ -213,8 +213,6 @@ _Last updated: $_GENERATED — rerun mac-headless to refresh status._
 - [$_TS] Authenticate Tailscale: \`sudo tailscale up\`
 - [$_GIT] Set git identity: \`git config --global user.name "Name" && git config --global user.email "you@example.com"\`
 - [$_GH] Authenticate GitHub CLI: \`gh auth login\`
-- [ ] Do NOT enable automatic login (System Settings -> Users & Groups -> Login Options) -- opening the lid should always require a password, never show an unlocked desktop
-- [ ] For background work (Claude, scheduled jobs) to run at boot without any GUI/SSH login ever happening, use a LaunchDaemon with \`UserName\` set to run as you (in /Library/LaunchDaemons, loaded at the system level) rather than a LaunchAgent, which needs a login session first. Before relying on this: verify whether Claude's stored credentials need your login Keychain unlocked (GUI login) to be read -- a LaunchDaemon started before any login may not be able to authenticate. Also check whether FileVault is enabled: if so, a full reboot stops at the pre-boot disk-unlock screen and nothing (not even the LaunchDaemon) starts until someone is physically there to unlock it.
 EOF
 
 ###############################################################################

--- a/mac-headless
+++ b/mac-headless
@@ -70,16 +70,27 @@ cask "claude-code"
 # Sharing since there's no physical display
 cask "google-chrome"
 
+# GUI apps -- for occasional Screen Sharing sessions
+cask "alfred"
+cask "iterm2"
+cask "rectangle"
+cask "textmate"
+
 # Libraries & tools
+brew "curl"
+brew "forego"
 brew "git"
 brew "gnupg"
 brew "openssl"
 brew "shellcheck"
 brew "jq"
+brew "yq"
 brew "htop"
 brew "the_silver_searcher"
+brew "tmate"
 brew "tmux"
 brew "vim"
+brew "wget"
 brew "zsh"
 brew "gh"
 brew "mise"

--- a/mac-headless
+++ b/mac-headless
@@ -101,8 +101,8 @@ EOF
 
 brew upgrade
 
-# Node.js via mise -- mono-node (the primary repo this box will work in)
-# standardizes on mise over nvm/nodenv, pinning versions per-repo via
+# Node.js via mise -- matches mono-node's (the primary repo this box will
+# work in) own toolchain convention, pinning versions per-repo via
 # mise.toml/.nvmrc. `mise use --global` just sets the fallback used outside
 # any pinned repo.
 if command -v mise > /dev/null 2>&1; then
@@ -161,12 +161,11 @@ sudo brew services start tailscale
 ###############################################################################
 
 # Prevent system sleep entirely (independent of the display, which stays off
-# with the lid closed) -- this is what actually keeps a lid-closed MacBook
-# reachable, no third-party keep-awake app needed. Also wake on network
-# access (lets SSH/Tailscale wake it if it ever does sleep) and auto-restart
-# after a power failure -- important for a box tucked away with no one
-# around to press the power button. Trade-off: no idle power savings, which
-# is the point for an always-on automation box.
+# with the lid closed) -- this is what keeps a lid-closed MacBook reachable.
+# Also wake on network access (lets SSH/Tailscale wake it if it ever does
+# sleep) and auto-restart after a power failure -- important for a box
+# tucked away with no one around to press the power button. Trade-off: no
+# idle power savings, which is the point for an always-on automation box.
 echo "Tuning pmset for unattended operation ..."
 sudo pmset -a disablesleep 1
 sudo pmset -a womp 1

--- a/mac-headless
+++ b/mac-headless
@@ -101,8 +101,7 @@ EOF
 
 brew upgrade
 
-# Node.js via mise -- matches mono-node's (the primary repo this box will
-# work in) own toolchain convention, pinning versions per-repo via
+# Node.js via mise, pinning versions per-repo via
 # mise.toml/.nvmrc. `mise use --global` just sets the fallback used outside
 # any pinned repo.
 if command -v mise > /dev/null 2>&1; then

--- a/mac-headless
+++ b/mac-headless
@@ -1,0 +1,283 @@
+#!/bin/sh
+
+# Welcome to the mac-headless machine script!
+# Sets up a headless MacBook Pro (Apple Silicon, lid closed, screen off) as a
+# Claude Code automation box: MCP-connected agent work now (e.g. Jira
+# cleanup), general dev work later. Reachable via SSH / Screen Sharing /
+# Tailscale, tuned to survive reboots and stay out of the way of unattended
+# automation. Actual sleep prevention with the lid closed is left to
+# Amphetamine (or similar) -- see the summary at the end.
+# After this script completes, follow the manual steps shown in the summary.
+
+# Ask for sudo upfront so we don't have to get it later
+sudo -v
+
+# Keep using sudo so the permissions don't time out
+while true; do sudo -n true; sleep 10; kill -0 "$$" || exit; done 2>/dev/null &
+
+# Run logging -- append one tab-separated line per run to ~/.laptop/runs.log so
+# it's easy to see which script ran on which host, when, for how long, against
+# which repo commit, and whether it succeeded. The commit is fetched lazily at
+# exit (via curl or wget) and falls back to "unknown" when offline or unset.
+LAPTOP_SCRIPT="mac-headless"
+LAPTOP_RUN_START=$(date +%s)
+
+log_run() {
+  _ret="$1"
+  _dur=$(( $(date +%s) - LAPTOP_RUN_START ))
+  if [ "$_ret" -eq 0 ]; then _outcome="ok"; else _outcome="fail"; fi
+  _api="https://api.github.com/repos/jonstorer/laptop/commits/main"
+  _commit=$( { curl -fsSL "$_api" 2>/dev/null || wget -qO- "$_api" 2>/dev/null; } \
+    | grep -m1 '"sha"' | cut -d'"' -f4 | cut -c1-12)
+  [ -n "$_commit" ] || _commit="unknown"
+  mkdir -p "$HOME/.laptop"
+  printf '%s\t%s\t%s\t%s\t%s\t%ss\texit=%s\n' \
+    "$(date '+%Y-%m-%dT%H:%M:%S%z')" \
+    "$LAPTOP_SCRIPT" "$(hostname)" "$_commit" \
+    "$_outcome" "$_dur" "$_ret" >> "$HOME/.laptop/runs.log"
+}
+
+# shellcheck disable=SC2154
+trap 'ret=$?; log_run "$ret"; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+set -e
+
+###############################################################################
+# Homebrew                                                                    #
+###############################################################################
+
+if ! command -v brew > /dev/null 2>&1; then
+  echo "Installing Homebrew ..."
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh')"
+fi
+
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+echo "Updating Homebrew ..."
+brew update --force
+
+brew bundle --file=- <<EOF
+# AI tooling
+cask "claude"
+cask "claude-code"
+
+# Browser -- one-time OAuth flows (Claude login, MCP auth) done over Screen
+# Sharing since there's no physical display
+cask "google-chrome"
+
+# Libraries & tools
+brew "git"
+brew "gnupg"
+brew "openssl"
+brew "shellcheck"
+brew "jq"
+brew "htop"
+brew "ripgrep"
+brew "tmux"
+brew "vim"
+brew "zsh"
+brew "gh"
+brew "nodenv"
+
+# Remote access
+brew "tailscale"
+EOF
+
+brew upgrade
+
+# Configure nodenv and install latest Node.js LTS
+if command -v nodenv > /dev/null 2>&1; then
+  echo "Setting up nodenv and Node.js ..."
+
+  # Node.js LTS releases use even-numbered major versions
+  latest_lts=$(nodenv install -l 2>/dev/null | sed 's/^[[:space:]]*//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '$1 % 2 == 0' | tail -1)
+  if [ -n "$latest_lts" ]; then
+    nodenv install -s "$latest_lts"
+    nodenv global "$latest_lts"
+    echo "Node.js $latest_lts set as global default"
+  fi
+
+  # Shell init (.zshrc) is managed by dotfiles - do not modify
+fi
+
+###############################################################################
+# zsh                                                                         #
+###############################################################################
+
+shell_path="$(command -v zsh)"
+echo "Ensuring default shell is zsh at '$shell_path' ..."
+if ! grep "$shell_path" /etc/shells > /dev/null 2>&1; then
+  sudo sh -c "echo $shell_path >> /etc/shells"
+fi
+if [ "$SHELL" != "$shell_path" ]; then
+  sudo chsh -s "$shell_path" "$USER"
+fi
+
+###############################################################################
+# SSH -- enable Remote Login for remote access                               #
+###############################################################################
+
+pgrep sshd > /dev/null 2>&1 || \
+  sudo launchctl load -w /System/Library/LaunchDaemons/ssh.plist
+
+###############################################################################
+# Screen Sharing -- enable for remote desktop (needed for interactive OAuth  #
+# steps, since the box has no physical display)                              #
+###############################################################################
+
+nc -z localhost 5900 2>/dev/null || \
+  sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.screensharing.plist
+
+###############################################################################
+# Tailscale -- start daemon (run 'sudo tailscale up' to authenticate)       #
+###############################################################################
+
+sudo brew services start tailscale
+
+###############################################################################
+# Power management -- tuned for an unattended box                            #
+###############################################################################
+
+# Wake on network access (lets SSH/Tailscale wake it if it does sleep) and
+# auto-restart after a power failure -- important for a box tucked away with
+# no one around to press the power button. Actual sleep *prevention* with the
+# lid closed is intentionally left to Amphetamine (see summary) rather than
+# scripted here with pmset disablesleep.
+sudo pmset -a womp 1
+sudo pmset -a autorestart 1
+
+###############################################################################
+# macOS defaults -- automation-friendly only                                 #
+###############################################################################
+
+echo "Configuring macOS defaults ..."
+
+# Keep background processes alive
+defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true
+
+# No iCloud document syncing
+defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
+
+# Reveal IP address, hostname, OS version when clicking clock in login window
+sudo defaults write /Library/Preferences/com.apple.loginwindow AdminHostInfo HostName
+
+# Locale
+defaults write NSGlobalDomain AppleLanguages -array "en"
+defaults write NSGlobalDomain AppleLocale -string "en_US@currency=USD"
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+
+# Require password immediately after screensaver
+defaults write com.apple.screensaver askForPassword -int 1
+defaults write com.apple.screensaver askForPasswordDelay -int 0
+
+# No .DS_Store on network volumes
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+
+# No confirmation dialogs that could block automation
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+defaults write com.apple.finder WarnOnEmptyTrash -bool false
+
+# Don't prompt to use new disks for Time Machine backups
+sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+
+for app in "Dock" "Finder" "SystemUIServer"; do
+  killall "$app" > /dev/null 2>&1 || true
+done
+
+echo "macOS defaults configured."
+
+###############################################################################
+# Scheduled jobs -- scaffolding only, no job installed yet                   #
+###############################################################################
+
+JOBS_DIR="$HOME/.laptop/jobs"
+mkdir -p "$JOBS_DIR"
+
+JOBS_README="$JOBS_DIR/README.md"
+if [ ! -f "$JOBS_README" ]; then
+  cat > "$JOBS_README" <<'EOF'
+# Scheduled jobs
+
+Convention for adding a recurring job to this box: a script here, plus a
+LaunchAgent that runs it on an interval. Follow the idempotent load pattern
+used by mac-openclaw's `poke-messages` agent (unload-then-reload, since
+`bootstrap` errors if the label is already loaded):
+
+    JOB_PLIST="$HOME/Library/LaunchAgents/com.user.<job-name>.plist"
+
+    cat > "$JOB_PLIST" <<PLIST
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>com.user.<job-name></string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>StartInterval</key>
+        <integer>300</integer>
+        <key>ProgramArguments</key>
+        <array>
+            <string>$HOME/.laptop/jobs/<job-name>.sh</string>
+        </array>
+    </dict>
+    </plist>
+    PLIST
+
+    launchctl bootout "gui/$(id -u)/com.user.<job-name>" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$JOB_PLIST"
+
+Use `StartCalendarInterval` instead of `StartInterval` for clock-time (rather
+than every-N-seconds) schedules.
+EOF
+fi
+
+###############################################################################
+# TODO.md -- manual steps with live status                                   #
+###############################################################################
+
+_ok() { sh -c "$1" > /dev/null 2>&1 && printf 'x' || printf ' '; }
+
+_CLAUDE=$(_ok "claude auth status")
+_MCP=$(_ok "claude mcp list | grep -qi atlassian")
+_TS=$(_ok "tailscale status")
+_GIT=$(_ok "git config --global user.name | grep -q . && git config --global user.email | grep -q .")
+_GH=$(_ok "gh auth status")
+_AUTOLOGIN=$(_ok "sudo defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser")
+_GENERATED=$(date '+%Y-%m-%d %H:%M:%S')
+TODO_FILE="$HOME/TODO.md"
+
+cat > "$TODO_FILE" <<EOF
+# Mac Headless Devbox Setup
+
+_Last updated: $_GENERATED — rerun mac-headless to refresh status._
+
+- [$_CLAUDE] Authenticate Claude CLI: \`claude\` (interactive TTY required -- use SSH or Screen Sharing)
+- [$_MCP] Add the Atlassian MCP for Jira cleanup: \`claude mcp add --transport sse atlassian https://mcp.atlassian.com/v1/sse\` then authenticate (opens a browser -- use Screen Sharing/Chrome)
+- [$_TS] Authenticate Tailscale: \`sudo tailscale up\`
+- [$_GIT] Set git identity: \`git config --global user.name "Name" && git config --global user.email "you@example.com"\`
+- [$_GH] Authenticate GitHub CLI: \`gh auth login\`
+- [$_AUTOLOGIN] Enable automatic login (survives unattended reboots): System Settings -> Users & Groups -> Login Options -> Automatic login. Not scripted here since it requires storing your account password.
+- [ ] Install & configure Amphetamine (or similar) from the App Store to keep the machine awake with the lid closed -- pmset alone won't prevent clamshell sleep on a MacBook with no external display
+- [ ] Add scheduled jobs under \`~/.laptop/jobs\` as needed (see \`~/.laptop/jobs/README.md\` for the LaunchAgent pattern)
+EOF
+
+###############################################################################
+# Summary                                                                     #
+###############################################################################
+
+LOCAL_IP="$(ipconfig getifaddr en0 2>/dev/null || echo 'unknown')"
+
+echo ""
+echo "============================================================"
+echo "Setup complete. This Mac is a headless Claude Code devbox."
+echo ""
+echo "Local IP:        $LOCAL_IP"
+echo "SSH:              ssh $USER@$LOCAL_IP"
+echo "Screen Sharing:   vnc://$LOCAL_IP"
+echo ""
+echo "Tailscale: daemon started -- run 'sudo tailscale up' to authenticate."
+echo "After auth, SSH and Screen Sharing work from anywhere via Tailscale IP."
+echo ""
+echo "Reminder: install Amphetamine to keep this box awake with the lid closed."
+echo "Manual steps: $TODO_FILE"
+echo "============================================================"

--- a/mac-headless
+++ b/mac-headless
@@ -49,6 +49,14 @@ set -e
 echo "macOS: $(sw_vers -productVersion 2>/dev/null || echo unknown), arch: $(uname -m)"
 
 ###############################################################################
+# Time sync -- clock skew breaks TLS verification for softwareupdate, which  #
+# Homebrew's installer uses to fetch the Xcode Command Line Tools           #
+###############################################################################
+
+echo "Syncing system clock ..."
+sudo sntp -sS time.apple.com 2>/dev/null || true
+
+###############################################################################
 # Homebrew                                                                    #
 ###############################################################################
 

--- a/mac-headless
+++ b/mac-headless
@@ -136,8 +136,7 @@ fi
 ###############################################################################
 
 echo "Enabling SSH Remote Login ..."
-pgrep sshd > /dev/null 2>&1 || \
-  sudo launchctl load -w /System/Library/LaunchDaemons/ssh.plist
+sudo systemsetup -setremotelogin on
 
 ###############################################################################
 # Screen Sharing -- enable for remote desktop (needed for interactive OAuth  #
@@ -202,7 +201,7 @@ defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
 defaults write com.apple.finder WarnOnEmptyTrash -bool false
 
 # Don't prompt to use new disks for Time Machine backups
-sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true 2>/dev/null || true
 
 for app in "Dock" "Finder" "SystemUIServer"; do
   killall "$app" > /dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- New `mac-headless` profile: sets up a headless MacBook Pro (Apple Silicon) as a Claude Code automation box — Claude Code CLI, Node via [mise](https://mise.jdx.dev), SSH/Screen Sharing/Tailscale for remote access, `pmset disablesleep` to keep the system running with the lid closed, and dev tools (iTerm2, TextMate, Alfred, Rectangle, tmate, forego, jq, yq, curl, wget) for occasional Screen Sharing sessions.
- Applies the automation-friendly subset of macOS defaults (no confirmation dialogs, no iCloud doc sync, no Time Machine new-disk prompts) and requires a password after screensaver/on Screen Sharing — opening the lid should never show an unlocked desktop.
- Writes a live-checked `TODO.md` for the manual steps this repo's convention leaves interactive: Claude auth, Atlassian MCP add+auth, Tailscale auth, git identity, gh auth.
- `LAPTOP_DEBUG=1` opts into full command tracing, and every previously-silent section (SSH, Screen Sharing, Tailscale, pmset) now announces itself, to make it easier to pinpoint a failure on a new machine.
- Updates `README.md` (support list, install section, what-it-sets-up section) and `.github/workflows/shellcheck.yml` to include the new script.

## Test plan
- [x] `shellcheck` passes clean on all profiles including `mac-headless`
- [ ] Run against a VM first (branch URL, `LAPTOP_DEBUG=1`, piped through `tee`) to shake out bugs before the real hardware
- [ ] Run end-to-end on the actual MacBook Pro hardware once it's racked in the closet
- [ ] Verify Claude Code can authenticate/run as expected under whatever headless-startup mechanism is used later, given FileVault is enabled on the target hardware (unattended full reboots will require physical unlock — accepted tradeoff for now)