### PR TITLE
Install systemd-timesyncd if missing before restarting it

### DIFF
--- a/ubuntu
+++ b/ubuntu
@@ -198,7 +198,10 @@ fi
 # Time sync -- clock skew breaks OAuth flows and GitHub Actions auth         #
 ###############################################################################
 
-sudo systemctl restart systemd-timesyncd
+if ! systemctl list-unit-files systemd-timesyncd.service > /dev/null 2>&1; then
+  sudo -E apt install -y systemd-timesyncd
+fi
+sudo systemctl enable --now systemd-timesyncd
 
 ###############################################################################
 # No desktop -- boot straight to a multi-user console                        #


### PR DESCRIPTION
## Summary
- The \`ubuntu\` script failed with \`set -e\` when \`systemd-timesyncd.service\` didn't exist on a minimal Ubuntu Server install. Install the package first if the unit isn't present, then enable/start it.

## Test plan
- [x] shellcheck passes
- [ ] Re-run `ubuntu` on the box, confirm it gets past the time-sync step

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JRNKn2V2Hp3CZNL9RZjE1e