### PR TITLE
Install Docker CE on the headless Ubuntu box

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Tailscale (runner install itself is a manual step — see below).
 
 **Browser:** Google Chrome stable (via Google's official apt repository) — headless browser automation for Claude Code
 
+**Docker:** Docker CE (cli, containerd, buildx, compose) via Docker's official apt repository; the service is enabled and the current user is added to the `docker` group — log out and back in (or `newgrp docker`) before running `docker` without sudo
+
 **Tailscale:** installed and enabled; run `sudo tailscale up` to authenticate
 
 **SSH:** openssh-server enabled and started; generates `~/.ssh/id_ed25519` if not present

--- a/ubuntu
+++ b/ubuntu
@@ -152,6 +152,41 @@ else
 fi
 
 ###############################################################################
+# Docker -- Docker CE from Docker's official apt repository                   #
+###############################################################################
+
+if ! command -v docker > /dev/null 2>&1; then
+  echo "Installing Docker ..."
+  sudo install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | sudo gpg --dearmor --batch --yes -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  # shellcheck disable=SC1091
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  wait_for_apt
+  sudo -E apt update
+  sudo -E apt install -y \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
+else
+  echo "Docker already installed, skipping."
+fi
+
+sudo systemctl enable --now docker
+
+# Run docker without sudo. Group membership only takes effect in new sessions,
+# so the current shell still needs sudo until the next login.
+if ! id -nG "$USER" | tr ' ' '\n' | grep -qx docker; then
+  echo "Adding $USER to the docker group ..."
+  sudo usermod -aG docker "$USER"
+  echo "Log out and back in (or run 'newgrp docker') to use docker without sudo."
+fi
+
+###############################################################################
 # Tailscale -- official apt repository                                        #
 ###############################################################################
 


### PR DESCRIPTION
The `ubuntu` script had no Docker, while `ubuntu-wsl` and `pi` both install it.

- Docker CE + cli, containerd, buildx, and compose plugins from Docker's official apt repo
- `systemctl enable --now docker`
- `$USER` added to the `docker` group (takes effect next login)
- README's Ubuntu section updated

Idempotent on reruns: install guarded by `command -v docker` (same pattern as gh / Claude Code / Chrome in this script), `gpg --dearmor --batch --yes` so re-dearmoring won't prompt, and both `systemctl enable --now` and the `usermod` are guarded no-ops.

Verified with `sh -n` and shellcheck 0.10.0 (clean). Not executed — no Ubuntu 26.04 host available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSNmyguaTewUcnttvGERWH